### PR TITLE
Fix append of `.grid` to all exported files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,8 +19,6 @@
 -   Loops
     -   Like `map` combined with `range`
 -   Key-value data structures
--   Functions?
--   Variables - already done?
 -   Add the rest of the (as-of-yet) untransferred wildcards.
     -   `time`, `beat`, `pulse`
 -   Pretty print lists

--- a/desktop/sources/scripts/browser.js
+++ b/desktop/sources/scripts/browser.js
@@ -101,7 +101,6 @@ function Browser (paradise) {
   this.export = function () {
     dialog.showSaveDialog({ title: 'Save World', filters: [{ name: 'Teapot Format', extensions: ['teapot'] }] }, (fileName) => {
       if (fileName === undefined) { return }
-      fileName = fileName.substr(-5, 5) != '.grid' ? fileName + '.grid' : fileName
       fs.writeFileSync(fileName, paradise.export())
     })
   }


### PR DESCRIPTION
This bug would prevent files from being imported without a rename.