### PR TITLE
Fix error message when typing `create` with no arguments

### DIFF
--- a/desktop/server/core/errors.js
+++ b/desktop/server/core/errors.js
@@ -24,7 +24,7 @@ const errors = {
   },
 
   LEARN: function (name) {
-    return new Error('err_LEARN', `For more details on how to ${name}, type "<action data='learn to ${this.name}'>learn to ${this.name}</action>".`)
+    return new Error('err_LEARN', `For more details on how to ${name}, type "<action data='learn to ${name}'>learn to ${name}</action>".`)
   },
 
   NOPROGRAM: function (target, usage = 'program') {


### PR DESCRIPTION
Currently, typing `create` with no arguments results in `undefined` being shown instead of `create` in the error message.

This PR fixes the error message to correctly show the command name.

### Before

![Screen Shot 2019-10-01 at 7 51 13 PM](https://user-images.githubusercontent.com/1486634/66008527-e75da200-e484-11e9-8ac6-a438b2110b65.png)

### After

![Screen Shot 2019-10-01 at 7 53 08 PM](https://user-images.githubusercontent.com/1486634/66008578-1d9b2180-e485-11e9-8ea4-1d952c74a4f0.png)
